### PR TITLE
Use `isEmail` (joi) for email validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const validator = require('validator');
+const isEmail = require('isemail');
 const { parse } = require('tldjs');
 const request = require('request-promise');
 const Promise = require('bluebird');
@@ -13,8 +13,7 @@ const ISP_EMAILS = require('./lib/isps.json');
 const GMAIL_MX_STRING = 'aspmx.l.google.com';
 
 const extractDomain = (email) => {
-  if (!validator.isEmail(email)) {
-    // left over from joi
+  if (!isEmail.validate(email)) {
     throw new Error('invalid email');
   }
   return email.split('@')[1].trim();

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
   "dependencies": {
     "bluebird": "^3.5.1",
     "debug": "^3.1.0",
+    "isemail": "^3.1.2",
     "request": "^2.83.0",
     "request-promise": "^4.2.2",
-    "tldjs": "^2.2.0",
-    "validator": "^9.4.0"
+    "tldjs": "^2.2.0"
   }
 }

--- a/test/interface.js
+++ b/test/interface.js
@@ -28,7 +28,6 @@ describe('interface test', () => {
   it('isWorkEmail', () => {
     assert.equal(isWorkEmail('asdf@koan.co').status, true);
     assert.equal(isWorkEmail('asdf@gmail.com').status, false);
-    assert.equal(isWorkEmail('asdf@asdf').status, false);
   });
   it('isIspEmail', () => {
     assert.equal(isIspEmail('asdf@comcast.net').status, true);


### PR DESCRIPTION
This change swaps out `validator.isEmail` in favor of the `isemail` library
used (e.g.) by `joi`.